### PR TITLE
Task: Prefix phantomjs.onconsole with \n>

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
   });
 
   // Pass-through console.log statements.
-  phantomjs.on('console', console.log.bind(console));
+  phantomjs.on('console', console.log.bind(console, '\n> '.cyan));
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {
     // Merge task-specific and/or target-specific options with these defaults.


### PR DESCRIPTION
This way, instead of having:

```
Testing qunit.........Some console log message
...
```

.. or verbose:

```
Testing qunit
Foo test...OK
Bar test...Some console log message
OK
Quux test...OK
```

It will now be like this:

```
Testing qunit.........
>  Some console log message
...
```

.. or verbose:

```
Testing qunit
Foo test...OK
Bar test...
> Some console log message
OK
Quux test...OK
```
