### PR TITLE
Emit spawn event on test start, containing the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,36 @@ grunt.initConfig({
 });
 ```
 
+#### Events and reporting
+The [callbacks from QUnit](http://api.qunitjs.com/category/callbacks/) are echoed through grunt's event system so that you may build custom reporting tools. The events, with arguments, are as follows:
+
+* `qunit.begin`
+* `qunit.moduleStart`: name
+* `qunit.testStart`: name
+* `qunit.log`: result, actual, expected, message, source
+* `qunit.testDone`: name, failed, passed, total
+* `qunit.moduleDone`: name, failed, passed, total
+* `qunit.done`: failed, passed, total, runtime
+
+Please refer to to the QUnit document for full details on the values each argument can take.
+Additionally we fire the following event when each test is spawned with PhantomJS:
+
+* `qunit.spawn`: url
+
+You can listen for these events like so:
+
+```js
+grunt.event.on('qunit.spawn', function (url) {
+  grunt.log.ok("Running test: " + url);
+});
+```
 
 ## Release History
 
- * 2012-10-04   v0.1.0   Work in progress, not yet officially released.
+ * 2012-10-05   v0.1.0   Work in progress, not yet officially released.
 
 ---
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Wed Nov 28 2012 08:54:17.*
+*This file was generated on Sun Dec 09 2012 18:30:44.*

--- a/docs/qunit-examples.md
+++ b/docs/qunit-examples.md
@@ -74,3 +74,27 @@ grunt.initConfig({
   }
 });
 ```
+
+## Events and reporting
+The [callbacks from QUnit](http://api.qunitjs.com/category/callbacks/) are echoed through grunt's event system so that you may build custom reporting tools. The events, with arguments, are as follows:
+
+* `qunit.begin`
+* `qunit.moduleStart`: name
+* `qunit.testStart`: name
+* `qunit.log`: result, actual, expected, message, source
+* `qunit.testDone`: name, failed, passed, total
+* `qunit.moduleDone`: name, failed, passed, total
+* `qunit.done`: failed, passed, total, runtime
+
+Please refer to to the QUnit documentation for full details on the values each argument can take.
+Additionally we fire the following event when a PhantomJS instance is spawned for a test:
+
+* `qunit.spawn`: url
+
+You can listen for these events like so:
+
+```js
+grunt.event.on('qunit.spawn', function (url) {
+  grunt.log.ok("Running test: " + url);
+});
+```

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -149,6 +149,7 @@ module.exports = function(grunt) {
     grunt.util.async.forEachSeries(urls, function(url, next) {
       var basename = path.basename(url);
       grunt.verbose.subhead('Testing ' + basename).or.write('Testing ' + basename);
+      grunt.event.emit('qunit.spawn', url);
 
       // Reset current module.
       currentModule = null;


### PR DESCRIPTION
Emit an event containing the test URL just before PhantomJS is spawned, so that reporters can build separate reports for each test.
