### PR TITLE
Add new events for fail conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,19 +155,21 @@ grunt.initConfig({
 #### Events and reporting
 [QUnit callback](http://api.qunitjs.com/category/callbacks/) methods and arguments are also emitted through grunt's event system so that you may build custom reporting tools. Please refer to to the QUnit documentation for more information.
 
-The events (with arguments) are as follows:
+The events, with arguments, are as follows:
 
 * `qunit.begin`
-* `qunit.moduleStart`: name
-* `qunit.testStart`: name
-* `qunit.log`: result, actual, expected, message, source
-* `qunit.testDone`: name, failed, passed, total
-* `qunit.moduleDone`: name, failed, passed, total
-* `qunit.done`: failed, passed, total, runtime
+* `qunit.moduleStart` `(name)`
+* `qunit.testStart` `(name)`
+* `qunit.log` `(result, actual, expected, message, source)`
+* `qunit.testDone` `(name, failed, passed, total)`
+* `qunit.moduleDone` `(name, failed, passed, total)`
+* `qunit.done` `(failed, passed, total, runtime)`
 
-In addition to QUnit callback-named events, the following event is emitted when [PhantomJS][] is spawned for a test:
+In addition to QUnit callback-named events, the following events are emitted by Grunt:
 
-* `qunit.spawn`: url
+* `qunit.spawn` `(url)`: when [PhantomJS][] is spawned for a test
+* `qunit.fail.load` `(url)`: when [PhantomJS][] could not open the given url
+* `qunit.fail.timeout`: when a QUnit test times out, usually due to a missing `QUnit.start()` call
 
 You may listen for these events like so:
 

--- a/docs/qunit-examples.md
+++ b/docs/qunit-examples.md
@@ -94,19 +94,21 @@ grunt.initConfig({
 ## Events and reporting
 [QUnit callback](http://api.qunitjs.com/category/callbacks/) methods and arguments are also emitted through grunt's event system so that you may build custom reporting tools. Please refer to to the QUnit documentation for more information.
 
-The events (with arguments) are as follows:
+The events, with arguments, are as follows:
 
 * `qunit.begin`
-* `qunit.moduleStart`: name
-* `qunit.testStart`: name
-* `qunit.log`: result, actual, expected, message, source
-* `qunit.testDone`: name, failed, passed, total
-* `qunit.moduleDone`: name, failed, passed, total
-* `qunit.done`: failed, passed, total, runtime
+* `qunit.moduleStart` `(name)`
+* `qunit.testStart` `(name)`
+* `qunit.log` `(result, actual, expected, message, source)`
+* `qunit.testDone` `(name, failed, passed, total)`
+* `qunit.moduleDone` `(name, failed, passed, total)`
+* `qunit.done` `(failed, passed, total, runtime)`
 
-In addition to QUnit callback-named events, the following event is emitted when [PhantomJS][] is spawned for a test:
+In addition to QUnit callback-named events, the following events are emitted by Grunt:
 
-* `qunit.spawn`: url
+* `qunit.spawn` `(url)`: when [PhantomJS][] is spawned for a test
+* `qunit.fail.load` `(url)`: when [PhantomJS][] could not open the given url
+* `qunit.fail.timeout`: when a QUnit test times out, usually due to a missing `QUnit.start()` call
 
 You may listen for these events like so:
 

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -117,12 +117,14 @@ module.exports = function(grunt) {
     phantomjs.halt();
     grunt.verbose.write('Running PhantomJS...').or.write('...');
     grunt.log.error();
+    grunt.event.emit('qunit.fail.load', url);
     grunt.warn('PhantomJS unable to load "' + url + '" URI.');
   });
 
   phantomjs.on('fail.timeout', function() {
     phantomjs.halt();
     grunt.log.writeln();
+    grunt.event.emit('qunit.fail.timeout');
     grunt.warn('PhantomJS timed out, possibly due to a missing QUnit start() call.');
   });
 


### PR DESCRIPTION
Custom reporting tools, such as my JUnit XML tool, need to know when a test completely fails, so they can output a generic failure report.
