### PR TITLE
Propagate error.onError events from Phantom

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -123,6 +123,11 @@ module.exports = function(grunt) {
     grunt.log.writeln();
     grunt.warn('PhantomJS timed out, possibly due to a missing QUnit start() call.');
   });
+  
+  phantomjs.on('error.onError', function (msg, stackTrace) {
+    grunt.event.emit('qunit.error.onError', msg, stackTrace);
+  });
+
 
   // Pass-through console.log statements.
   phantomjs.on('console', console.log.bind(console));


### PR DESCRIPTION
They can then be handled in Gruntfile.js using 
grunt.event.on('qunit.error.onError', function (msg, stack) { ... })
