### PR TITLE
Multi-test qunit targets don't fail if a child test has no assertions

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -152,8 +152,7 @@ module.exports = function(grunt) {
     // Process each filepath in-order.
     grunt.util.async.forEachSeries(urls, function(url, next) {
       var basename = path.basename(url);
-      grunt.verbose.subhead('Testing ' + url).or.write('Testing ' + url);
-      console.log(); // add newline
+      grunt.verbose.subhead('Testing ' + url + ' ').or.write('Testing ' + url + ' ');
 
       // Reset current module.
       currentModule = null;


### PR DESCRIPTION
Currently the check for 0/0 assertions only happens after an entire qunit target run, so if I have a list of 3 URLs and 2 of them each have 10 assertions, but the third as 0 assertions the qunit target will pass saying it ran 20/20 assertions.

If the third test is a standalone qunit target, it will fail with a message about no assertions.

This commit ensures that each test suite actually has assertions, rather than only checking at the qunit target complete time.

As a minor vanity point it adds a space between the URL and the dot printing to make the URLs clickable.
