### PR TITLE
Wrap bridge.js in a function to keep  from polluting global name space

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -7,51 +7,52 @@
  */
 
 /*global QUnit:true, alert:true*/
+(function () {
+  'use strict';
 
-'use strict';
+  // Don't re-order tests.
+  QUnit.config.reorder = false;
+  // Run tests serially, not in parallel.
+  QUnit.config.autorun = false;
 
-// Don't re-order tests.
-QUnit.config.reorder = false;
-// Run tests serially, not in parallel.
-QUnit.config.autorun = false;
+  // Send messages to the parent PhantomJS process via alert! Good times!!
+  function sendMessage() {
+    var args = [].slice.call(arguments);
+    alert(JSON.stringify(args));
+  }
 
-// Send messages to the parent PhantomJS process via alert! Good times!!
-function sendMessage() {
-  var args = [].slice.call(arguments);
-  alert(JSON.stringify(args));
-}
+  // These methods connect QUnit to PhantomJS.
+  QUnit.log(function(obj) {
+    // What is this I don’t even
+    if (obj.message === '[object Object], undefined:undefined') { return; }
+    // Parse some stuff before sending it.
+    var actual = QUnit.jsDump.parse(obj.actual);
+    var expected = QUnit.jsDump.parse(obj.expected);
+    // Send it.
+    sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
+  });
 
-// These methods connect QUnit to PhantomJS.
-QUnit.log(function(obj) {
-  // What is this I don’t even
-  if (obj.message === '[object Object], undefined:undefined') { return; }
-  // Parse some stuff before sending it.
-  var actual = QUnit.jsDump.parse(obj.actual);
-  var expected = QUnit.jsDump.parse(obj.expected);
-  // Send it.
-  sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
-});
+  QUnit.testStart(function(obj) {
+    sendMessage('qunit.testStart', obj.name);
+  });
 
-QUnit.testStart(function(obj) {
-  sendMessage('qunit.testStart', obj.name);
-});
+  QUnit.testDone(function(obj) {
+    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total);
+  });
 
-QUnit.testDone(function(obj) {
-  sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total);
-});
+  QUnit.moduleStart(function(obj) {
+    sendMessage('qunit.moduleStart', obj.name);
+  });
 
-QUnit.moduleStart(function(obj) {
-  sendMessage('qunit.moduleStart', obj.name);
-});
+  QUnit.moduleDone(function(obj) {
+    sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
+  });
 
-QUnit.moduleDone(function(obj) {
-  sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
-});
+  QUnit.begin(function() {
+    sendMessage('qunit.begin');
+  });
 
-QUnit.begin(function() {
-  sendMessage('qunit.begin');
-});
-
-QUnit.done(function(obj) {
-  sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
-});
+  QUnit.done(function(obj) {
+    sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
+  });
+}());


### PR DESCRIPTION
It is occasionally desired to have a unit test that checks if a library affects variables in the global name space. The existing bridge.js declares a global function `sendMessage` for internal use, which affects such a test and could potentially conflict with an existing function by the same name.

This patch wraps the entire bridge.js in a closure to keep `sendMessage` private.
