### PR TITLE
add an option to disable the warning for tests with no assertions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,8 +61,18 @@ module.exports = function(grunt) {
         },
         src: 'test/*{1,2}.html',
       },
+      warnings_enabled: {
+        options: {
+          warnOnMissingAssertions: true
+        }
+      },
+      warnings_disabled: {
+        options: {
+          files: ['test/*3.html'],
+          warnOnMissingAssertions: false
+        }
+      }
     }
-
   });
 
   // Build a mapping of url success counters.

--- a/docs/qunit-options.md
+++ b/docs/qunit-options.md
@@ -18,6 +18,12 @@ Default: `[]`
 
 Absolute `http://` or `https://` urls to be passed to PhantomJS. Specified URLs will be merged with any specified `src` files first. Note that urls must be served by a web server, and since this task doesn't contain a web server, one will need to be configured separately. The [grunt-contrib-connect plugin](https://github.com/gruntjs/grunt-contrib-connect) provides a basic web server.
 
+## warnOnMissingAssertions
+Type: `Boolean`  
+Default: true
+
+As of version 0.2.2 a warning will be issued if you have a test that does not include any assertion. If `warnOnMissingAssertions` is set to false no warnings will be issued. It is recommended to have this option set to true (the default).
+
 ## (-- PhantomJS arguments)
 Type: `String`  
 Default: (none)

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -138,6 +138,8 @@ module.exports = function(grunt) {
       inject: asset('phantomjs/bridge.js'),
       // Explicit non-file URLs to test.
       urls: [],
+      // warn about tests with no assertions
+      warnOnMissingAssertions: true
     });
 
     // Combine any specified URLs with src files.
@@ -171,7 +173,7 @@ module.exports = function(grunt) {
             // Otherwise, process next url.
             next();
           }
-        },
+        }
       });
     },
     // All tests have been run.
@@ -180,7 +182,7 @@ module.exports = function(grunt) {
       if (status.failed > 0) {
         grunt.warn(status.failed + '/' + status.total + ' assertions failed (' +
           status.duration + 'ms)');
-      } else if (status.total === 0) {
+      } else if (status.total === 0 && options.warnOnMissingAssertions) {
         grunt.warn('0/0 assertions ran (' + status.duration + 'ms)');
       } else {
         grunt.verbose.writeln();

--- a/test/qunit3.html
+++ b/test/qunit3.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Basic Test Suite </title>
+  <!-- Load local QUnit. -->
+  <link rel="stylesheet" href="libs/qunit.css" media="screen">
+  <script src="libs/qunit.js"></script>
+  <!-- Load local lib and tests. -->
+  <script src="qunit_test_wo_assertions.js"></script>
+</head>
+<body>
+  <h1 id="qunit-header">Basic Test Suite</h1>
+  <h2 id="qunit-banner"></h2>
+  <div id="qunit-testrunner-toolbar"></div>
+  <h2 id="qunit-userAgent"></h2>
+  <ol id="qunit-tests"></ol>
+  <div id="qunit-fixture">this had better work.</div>
+</body>
+</html>

--- a/test/qunit_test_wo_assertions.js
+++ b/test/qunit_test_wo_assertions.js
@@ -1,0 +1,5 @@
+
+test('a test without assertions', function() {
+  expect(0);
+
+});


### PR DESCRIPTION
I did not find any information how to test the gruntfile itself, so here is a proof of the working status:

```
>grunt qunit:warnings_disabled
Running "qunit:warnings_disabled" (qunit) task
>> 0 assertions passed (0ms)

Done, without errors.

>grunt qunit:warnings_enabled
Running "qunit:warnings_enabled" (qunit) task
Warning: 0/0 assertions ran (0ms) Use --force to continue.

Aborted due to warnings.
```

I'm open to shorter names for this option :) Maybe we could name it "strict" and apply 
other good practices for testing here (see strict mode from phpunit)

I hope you did not mind removing some trailing commas here and there...

best regards
philipp
