### PR TITLE
Removing Confusing Error Message

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
   // Built-in error handlers.
   phantomjs.on('fail.load', function(url) {
     phantomjs.halt();
-    grunt.verbose.write('Running PhantomJS...').or.write('...');
+    grunt.verbose.write('...');
     grunt.event.emit('qunit.fail.load', url);
     grunt.log.error('PhantomJS unable to load "' + url + '" URI.');
     status.failed += 1;


### PR DESCRIPTION
If PhantomJS is throwing a fail.load error, saying **"Running PhantomJS"** does not make it clear to the user what's going on - especially if the message only appears in **grunt.verbose**.

Allowing "PhantomJS is unable to load" to appear earlier is better.
