### PR TITLE
Only call jsDump.parse() if a test failed

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -25,9 +25,15 @@
   QUnit.log(function(obj) {
     // What is this I don’t even
     if (obj.message === '[object Object], undefined:undefined') { return; }
+
     // Parse some stuff before sending it.
-    var actual = QUnit.jsDump.parse(obj.actual);
-    var expected = QUnit.jsDump.parse(obj.expected);
+    var actual, expected;
+    if (!obj.result) {
+      // Dumping large objects can be very slow, and the dump isn't used for
+      // passing tests, so only dump if the test failed.
+      actual = QUnit.jsDump.parse(obj.actual);
+      expected = QUnit.jsDump.parse(obj.expected);
+    }
     // Send it.
     sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
   });


### PR DESCRIPTION
`jsDump.parse()` can be very slow in cases of deeply-nested objects. Normal in-browser QUnit only calls it on the arguments to failing tests, but grunt-contrib-qunit calls it on all arguments to _all_ tests. On a work project, we've been seeing a 150x slowdown using grunt-contrib-qunit versus executing the QUnit tests in Chromium.

This patch makes grunt-contrib-qunit's test runner match QUnit's behavior: objects are only dumped if the test fails. This has no effect on the test runner's behavior (the dumped object was never actually used if a test passed), and eliminates the discrepancy in performance.

Merging this should resolve issue #44.
