### PR TITLE
Adding qunit.css to tasks folder, altering .gitignore for intellij files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 npm-debug.log
 tmp
+.idea/*
+*.iml

--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ grunt.event.on('qunit.spawn', function (url) {
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Mon Jan 27 2014 20:45:25.*
+*This file was generated on Wed Mar 19 2014 08:14:43.*

--- a/tasks/qunit.css
+++ b/tasks/qunit.css
@@ -1,0 +1,244 @@
+/**
+ * QUnit v1.12.0 - A JavaScript Unit Testing Framework
+ *
+ * http://qunitjs.com
+ *
+ * Copyright 2012 jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * http://jquery.org/license
+ */
+
+/** Font Family and Sizes */
+
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult {
+  font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
+}
+
+#qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult, #qunit-tests li { font-size: small; }
+#qunit-tests { font-size: smaller; }
+
+
+/** Resets */
+
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult, #qunit-modulefilter {
+  margin: 0;
+  padding: 0;
+}
+
+
+/** Header */
+
+#qunit-header {
+  padding: 0.5em 0 0.5em 1em;
+
+  color: #8699a4;
+  background-color: #0d3349;
+
+  font-size: 1.5em;
+  line-height: 1em;
+  font-weight: normal;
+
+  border-radius: 5px 5px 0 0;
+  -moz-border-radius: 5px 5px 0 0;
+  -webkit-border-top-right-radius: 5px;
+  -webkit-border-top-left-radius: 5px;
+}
+
+#qunit-header a {
+  text-decoration: none;
+  color: #c2ccd1;
+}
+
+#qunit-header a:hover,
+#qunit-header a:focus {
+  color: #fff;
+}
+
+#qunit-testrunner-toolbar label {
+  display: inline-block;
+  padding: 0 .5em 0 .1em;
+}
+
+#qunit-banner {
+  height: 5px;
+}
+
+#qunit-testrunner-toolbar {
+  padding: 0.5em 0 0.5em 2em;
+  color: #5E740B;
+  background-color: #eee;
+  overflow: hidden;
+}
+
+#qunit-userAgent {
+  padding: 0.5em 0 0.5em 2.5em;
+  background-color: #2b81af;
+  color: #fff;
+  text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
+}
+
+#qunit-modulefilter-container {
+  float: right;
+}
+
+/** Tests: Pass/Fail */
+
+#qunit-tests {
+  list-style-position: inside;
+}
+
+#qunit-tests li {
+  padding: 0.4em 0.5em 0.4em 2.5em;
+  border-bottom: 1px solid #fff;
+  list-style-position: inside;
+}
+
+#qunit-tests.hidepass li.pass, #qunit-tests.hidepass li.running  {
+  display: none;
+}
+
+#qunit-tests li strong {
+  cursor: pointer;
+}
+
+#qunit-tests li a {
+  padding: 0.5em;
+  color: #c2ccd1;
+  text-decoration: none;
+}
+#qunit-tests li a:hover,
+#qunit-tests li a:focus {
+  color: #000;
+}
+
+#qunit-tests li .runtime {
+  float: right;
+  font-size: smaller;
+}
+
+.qunit-assert-list {
+  margin-top: 0.5em;
+  padding: 0.5em;
+
+  background-color: #fff;
+
+  border-radius: 5px;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+}
+
+.qunit-collapsed {
+  display: none;
+}
+
+#qunit-tests table {
+  border-collapse: collapse;
+  margin-top: .2em;
+}
+
+#qunit-tests th {
+  text-align: right;
+  vertical-align: top;
+  padding: 0 .5em 0 0;
+}
+
+#qunit-tests td {
+  vertical-align: top;
+}
+
+#qunit-tests pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+#qunit-tests del {
+  background-color: #e0f2be;
+  color: #374e0c;
+  text-decoration: none;
+}
+
+#qunit-tests ins {
+  background-color: #ffcaca;
+  color: #500;
+  text-decoration: none;
+}
+
+/*** Test Counts */
+
+#qunit-tests b.counts                       { color: black; }
+#qunit-tests b.passed                       { color: #5E740B; }
+#qunit-tests b.failed                       { color: #710909; }
+
+#qunit-tests li li {
+  padding: 5px;
+  background-color: #fff;
+  border-bottom: none;
+  list-style-position: inside;
+}
+
+/*** Passing Styles */
+
+#qunit-tests li li.pass {
+  color: #3c510c;
+  background-color: #fff;
+  border-left: 10px solid #C6E746;
+}
+
+#qunit-tests .pass                          { color: #528CE0; background-color: #D2E0E6; }
+#qunit-tests .pass .test-name               { color: #366097; }
+
+#qunit-tests .pass .test-actual,
+#qunit-tests .pass .test-expected           { color: #999999; }
+
+#qunit-banner.qunit-pass                    { background-color: #C6E746; }
+
+/*** Failing Styles */
+
+#qunit-tests li li.fail {
+  color: #710909;
+  background-color: #fff;
+  border-left: 10px solid #EE5757;
+  white-space: pre;
+}
+
+#qunit-tests > li:last-child {
+  border-radius: 0 0 5px 5px;
+  -moz-border-radius: 0 0 5px 5px;
+  -webkit-border-bottom-right-radius: 5px;
+  -webkit-border-bottom-left-radius: 5px;
+}
+
+#qunit-tests .fail                          { color: #000000; background-color: #EE5757; }
+#qunit-tests .fail .test-name,
+#qunit-tests .fail .module-name             { color: #000000; }
+
+#qunit-tests .fail .test-actual             { color: #EE5757; }
+#qunit-tests .fail .test-expected           { color: green;   }
+
+#qunit-banner.qunit-fail                    { background-color: #EE5757; }
+
+
+/** Result */
+
+#qunit-testresult {
+  padding: 0.5em 0.5em 0.5em 2.5em;
+
+  color: #2b81af;
+  background-color: #D2E0E6;
+
+  border-bottom: 1px solid white;
+}
+#qunit-testresult .module-name {
+  font-weight: bold;
+}
+
+/** Fixture */
+
+#qunit-fixture {
+  position: absolute;
+  top: -10000px;
+  left: -10000px;
+  width: 1000px;
+  height: 1000px;
+}


### PR DESCRIPTION
Adding the qunit.css file to the tasks folder so that we can use the node_modules version of qunit to run our tests via the browser. Should help to reduce issues where the tests pass in the browser but fail in the console due to version mismatch. (New to grunt plugins, let me know if this doesn't work at all. I would love to learn some more)
