### PR TITLE
Use HTTP base to serve src files

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -155,7 +155,7 @@ module.exports = function(grunt) {
       urls: [],
       force: false,
       // Connect phantomjs console output to grunt output
-      console: true
+      console: true,
       // Do not use an HTTP base by default
       httpBase: false
     });


### PR DESCRIPTION
I needed the ability to host tests without knowing the files.

There seems to be a limitation currently: one can provide a list of explicit URLs or the usual "src" matchers. I have added to the task so that if there is an "httpBase" option present, all src files are prefixed with that base.

My config now looks like:

```
module.exports = function(grunt) {
    grunt.initConfig ({
        connect: {
            options: {
                base: '.',
                port: 8001
            },
            test: {
                options: {
                    keepalive: false
                }
            }
        },
        qunit: {
            tests: {
                options: {
                    httpBase: 'http://localhost:8001'
                },
                src: 'devel/tests/*.html'
            }
        }
...
```

That will:
1) start an HTTP server, hosting the QUnit HTML documents
2) expand the src files to ['devel/tests/TestSomething.html', 'devel/tests/TestAnother.html']
3) Add to the `urls` array: ['http://localhost:8001/devel/tests/TestSomething.html', 'http://localhost:8001/devel/tests/TestAnother.html']
4) Run the tests as normal
