### PR TITLE
Grunt: Remove redundant 'jshint' from 'default' task list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint', 'connect', 'qunit', 'really-test']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);
+  grunt.registerTask('default', ['test', 'build-contrib']);
 
 };


### PR DESCRIPTION
Follows-up 7064d2d84db84ff which added `jshint` to `test`, which is already included in `default`.
