### PR TITLE
Fixes exit codes by passing failures back to Grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-qunit v0.5.2 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-qunit.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-qunit) <a href="https://ci.appveyor.com/project/gruntjs/grunt-contrib-qunit"><img src="https://ci.appveyor.com/api/projects/status/3vd43779joyj6qji/branch/master" alt="Build Status: Windows" height="18" /></a>
+# grunt-contrib-qunit v0.5.2 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-qunit.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-qunit)
 
 > Run QUnit unit tests in a headless PhantomJS instance.
 
@@ -173,7 +173,7 @@ grunt.registerTask('test', ['connect', 'qunit']);
 #### Custom timeouts and PhantomJS options
 In the following example, the default timeout value of `5000` is overridden with the value `10000` (timeout values are in milliseconds). Additionally, PhantomJS will read stored cookies from the specified file. See the [PhantomJS API Reference][] for a list of `--` options that PhantomJS supports.
 
-[PhantomJS API Reference]: http://phantomjs.org/api/
+[PhantomJS API Reference]: https://github.com/ariya/phantomjs/wiki/API-Reference
 
 ```js
 // Project configuration.
@@ -236,4 +236,4 @@ grunt.event.on('qunit.spawn', function (url) {
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Wed Jul 09 2014 08:27:15.*
+*This file was generated on Wed Jan 14 2015 09:53:59.*

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -233,7 +233,7 @@ module.exports = function(grunt) {
         grunt.log.ok(status.total + ' assertions passed (' + status.duration + 'ms)');
       }
       // All done!
-      done();
+      done(status.failed === 0);
     });
   });
 


### PR DESCRIPTION
The QUnit task does not report failures to Grunt in a way that changes the exit code. Therefore Grunt returns a successful exit code for test failures. This seems (to me) to be undesirable behaviour. This has been fixed by passing true/false into the task callback.

Ironically, this causes the tests for the task to fail prematurely because of the `noglobals` test. Running `grunt --force` fixes this, but that doesn't feel like the correct way of handling this.

If there are any suggestions on how to fix that, I'll be happy to implement them, but I've never been able to figure out how to test code that is _expected_ to fail...