### PR TITLE
Adjust bridge for use with AMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,24 +190,7 @@ grunt.initConfig({
 
 #### Loading QUnit with AMD
 
-When loading QUnit and the associated test files via AMD, you can set the `inject` option to `null` and then load the `phantomjs/bridge.js` module. This module exports a single function which should be invoked after loading QUnit, but before any tests are loaded.
-
-For instance, you can create a module to load in place of the standard QUnit module (make sure to use a proper path to the bridge based on your config and directory structure):
-
-```js
-define(
-  ['qunit','node_modules/grunt-contrib-qunit/phantomjs/bridge'],
-  function(QUnit, bridge) {
-    // Only load the bridge if we're testing inside PhantomJS
-    if ( /PhantomJS/.test( navigator.userAgent ) ) {
-      bridge();
-    }
-
-    // Return QUnit so this module can be loaded in place of the standard QUnit module
-    return QUnit;
-  }
-);
-```
+When using AMD to load QUnit and your tests, make sure to have a path for the `qunit` module defined.
 
 #### Events and reporting
 [QUnit callback](http://api.qunitjs.com/category/callbacks/) methods and arguments are also emitted through grunt's event system so that you may build custom reporting tools. Please refer to to the QUnit documentation for more information.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,27 @@ grunt.initConfig({
 });
 ```
 
+#### Loading QUnit with AMD
+
+When loading QUnit and the associated test files via AMD, you can set the `inject` option to `null` and then load the `phantomjs/bridge.js` module. This module exports a single function which should be invoked after loading QUnit, but before any tests are loaded.
+
+For instance, you can create a module to load in place of the standard QUnit module (make sure to use a proper path to the bridge based on your config and directory structure):
+
+```js
+define(
+  ['qunit','node_modules/grunt-contrib-qunit/phantomjs/bridge'],
+  function(QUnit, bridge) {
+    // Only load the bridge if we're testing inside PhantomJS
+    if ( /PhantomJS/.test( navigator.userAgent ) ) {
+      bridge();
+    }
+
+    // Return QUnit so this module can be loaded in place of the standard QUnit module
+    return QUnit;
+  }
+);
+```
+
 #### Events and reporting
 [QUnit callback](http://api.qunitjs.com/category/callbacks/) methods and arguments are also emitted through grunt's event system so that you may build custom reporting tools. Please refer to to the QUnit documentation for more information.
 

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -7,58 +7,66 @@
  */
 
 /*global QUnit:true, alert:true*/
-(function () {
+(function (global, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['qunit'], factory);
+  } else {
+    factory(QUnit)();
+  }
+}(this, function(QUnit) {
   'use strict';
 
-  // Don't re-order tests.
-  QUnit.config.reorder = false;
-  // Run tests serially, not in parallel.
-  QUnit.config.autorun = false;
+  return function() {
+    // Don't re-order tests.
+    QUnit.config.reorder = false;
+    // Run tests serially, not in parallel.
+    QUnit.config.autorun = false;
 
-  // Send messages to the parent PhantomJS process via alert! Good times!!
-  function sendMessage() {
-    var args = [].slice.call(arguments);
-    alert(JSON.stringify(args));
-  }
-
-  // These methods connect QUnit to PhantomJS.
-  QUnit.log(function(obj) {
-    // What is this I don’t even
-    if (obj.message === '[object Object], undefined:undefined') { return; }
-
-    // Parse some stuff before sending it.
-    var actual, expected;
-    if (!obj.result) {
-      // Dumping large objects can be very slow, and the dump isn't used for
-      // passing tests, so only dump if the test failed.
-      actual = QUnit.jsDump.parse(obj.actual);
-      expected = QUnit.jsDump.parse(obj.expected);
+    // Send messages to the parent PhantomJS process via alert! Good times!!
+    function sendMessage() {
+      var args = [].slice.call(arguments);
+      alert(JSON.stringify(args));
     }
-    // Send it.
-    sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
-  });
 
-  QUnit.testStart(function(obj) {
-    sendMessage('qunit.testStart', obj.name);
-  });
+    // These methods connect QUnit to PhantomJS.
+    QUnit.log(function(obj) {
+      // What is this I don’t even
+      if (obj.message === '[object Object], undefined:undefined') { return; }
 
-  QUnit.testDone(function(obj) {
-    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration);
-  });
+      // Parse some stuff before sending it.
+      var actual, expected;
+      if (!obj.result) {
+        // Dumping large objects can be very slow, and the dump isn't used for
+        // passing tests, so only dump if the test failed.
+        actual = QUnit.jsDump.parse(obj.actual);
+        expected = QUnit.jsDump.parse(obj.expected);
+      }
+      // Send it.
+      sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
+    });
 
-  QUnit.moduleStart(function(obj) {
-    sendMessage('qunit.moduleStart', obj.name);
-  });
+    QUnit.testStart(function(obj) {
+      sendMessage('qunit.testStart', obj.name);
+    });
 
-  QUnit.moduleDone(function(obj) {
-    sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
-  });
+    QUnit.testDone(function(obj) {
+      sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration);
+    });
 
-  QUnit.begin(function() {
-    sendMessage('qunit.begin');
-  });
+    QUnit.moduleStart(function(obj) {
+      sendMessage('qunit.moduleStart', obj.name);
+    });
 
-  QUnit.done(function(obj) {
-    sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
-  });
-}());
+    QUnit.moduleDone(function(obj) {
+      sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
+    });
+
+    QUnit.begin(function() {
+      sendMessage('qunit.begin');
+    });
+
+    QUnit.done(function(obj) {
+      sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
+    });
+  };
+}));

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -7,66 +7,64 @@
  */
 
 /*global QUnit:true, alert:true*/
-(function (global, factory) {
+(function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['qunit'], factory);
+    require(['qunit'], factory);
   } else {
-    factory(QUnit)();
+    factory(QUnit);
   }
-}(this, function(QUnit) {
+}(function(QUnit) {
   'use strict';
 
-  return function() {
-    // Don't re-order tests.
-    QUnit.config.reorder = false;
-    // Run tests serially, not in parallel.
-    QUnit.config.autorun = false;
+  // Don't re-order tests.
+  QUnit.config.reorder = false;
+  // Run tests serially, not in parallel.
+  QUnit.config.autorun = false;
 
-    // Send messages to the parent PhantomJS process via alert! Good times!!
-    function sendMessage() {
-      var args = [].slice.call(arguments);
-      alert(JSON.stringify(args));
+  // Send messages to the parent PhantomJS process via alert! Good times!!
+  function sendMessage() {
+    var args = [].slice.call(arguments);
+    alert(JSON.stringify(args));
+  }
+
+  // These methods connect QUnit to PhantomJS.
+  QUnit.log(function(obj) {
+    // What is this I don’t even
+    if (obj.message === '[object Object], undefined:undefined') { return; }
+
+    // Parse some stuff before sending it.
+    var actual, expected;
+    if (!obj.result) {
+      // Dumping large objects can be very slow, and the dump isn't used for
+      // passing tests, so only dump if the test failed.
+      actual = QUnit.jsDump.parse(obj.actual);
+      expected = QUnit.jsDump.parse(obj.expected);
     }
+    // Send it.
+    sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
+  });
 
-    // These methods connect QUnit to PhantomJS.
-    QUnit.log(function(obj) {
-      // What is this I don’t even
-      if (obj.message === '[object Object], undefined:undefined') { return; }
+  QUnit.testStart(function(obj) {
+    sendMessage('qunit.testStart', obj.name);
+  });
 
-      // Parse some stuff before sending it.
-      var actual, expected;
-      if (!obj.result) {
-        // Dumping large objects can be very slow, and the dump isn't used for
-        // passing tests, so only dump if the test failed.
-        actual = QUnit.jsDump.parse(obj.actual);
-        expected = QUnit.jsDump.parse(obj.expected);
-      }
-      // Send it.
-      sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
-    });
+  QUnit.testDone(function(obj) {
+    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration);
+  });
 
-    QUnit.testStart(function(obj) {
-      sendMessage('qunit.testStart', obj.name);
-    });
+  QUnit.moduleStart(function(obj) {
+    sendMessage('qunit.moduleStart', obj.name);
+  });
 
-    QUnit.testDone(function(obj) {
-      sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration);
-    });
+  QUnit.moduleDone(function(obj) {
+    sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
+  });
 
-    QUnit.moduleStart(function(obj) {
-      sendMessage('qunit.moduleStart', obj.name);
-    });
+  QUnit.begin(function() {
+    sendMessage('qunit.begin');
+  });
 
-    QUnit.moduleDone(function(obj) {
-      sendMessage('qunit.moduleDone', obj.name, obj.failed, obj.passed, obj.total);
-    });
-
-    QUnit.begin(function() {
-      sendMessage('qunit.begin');
-    });
-
-    QUnit.done(function(obj) {
-      sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
-    });
-  };
+  QUnit.done(function(obj) {
+    sendMessage('qunit.done', obj.failed, obj.passed, obj.total, obj.runtime);
+  });
 }));


### PR DESCRIPTION
This makes it easy to load the built-in bridge as an AMD module when loading QUnit through AMD.

I can add some documentation for this if this looks good. I've tested this against a local branch of jQuery UI which has been modified to load QUnit and all tests through AMD. After loading QUnit and the bridge via AMD, I'm using the following code to apply the bridge (let me know if you'd like more context):

```js
if ( /PhantomJS/.test( navigator.userAgent ) ) {
	bridge();
}
```

I can add a test as well, but I'm not sure if you want an actual AMD loader in the dev dependencies. Adding a test will also require a new release of QUnit (plus https://github.com/jquery/qunit/pull/791). Getting proper AMD tests in jQuery UI has opened quite the rabbit hole ;-)