### PR TITLE
Warn for errors from PhantomJS

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -143,8 +143,9 @@ module.exports = function(grunt) {
 
   phantomjs.on('error.onError', function (msg, stackTrace) {
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
+    grunt.log.warn('PhantomJS error:\n', msg, '\n', stackTrace);
   });
-  
+
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     options = this.options({


### PR DESCRIPTION
This helps find issues where files failed to load, which usually causes the PhantomJS process to timeout, without any indicator of the underlying problem.

Any reason not to add this?