### PR TITLE
Correct phantomjs.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 When installed by npm, this plugin will automatically download and install [PhantomJS][] locally via the [grunt-lib-phantomjs][] library.
 
-[PhantomJS]: http://www.phantomjs.org/
+[PhantomJS]: http://phantomjs.org/
 [grunt-lib-phantomjs]: https://github.com/gruntjs/grunt-lib-phantomjs
 
 Also note that running grunt with the `--debug` flag will output a lot of PhantomJS-specific debugging information. This can be very helpful in seeing what actual URIs are being requested and received by PhantomJS.


### PR DESCRIPTION
README.md referred to www.phantomjs.og. The correct address is phantomjs.org.