### PR TITLE
added httpBase.host and httpBase.doRewrite configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Default: `false`
 
 Create URLs for the `src` files, all `src` files are prefixed with that base.
 
+#### httpBase
+Type: `Object`
+Default: `false`
+
+httpBase.host 
+Type: `String`
+
+httpBase.doRewrite
+Type: `Function`
+Create URLs for the `src` files, all `src` files are prefixed with httpBase.host and rewritten by the callback defined in `doRewrite`.
+
 #### console
 Type: `boolean`
 Default: `true`
@@ -131,6 +142,31 @@ grunt.initConfig({
 ```
 
 Wildcards and URLs may be combined by specifying both.
+
+#### Testing via http:// or https:// using httpBase Object and Wildcards
+You might want to do a Wildcard test for all `.html` files on a custom server but the server is mapping the
+url's differently.
+
+In this example, the test files are located in `src/main/resources/META-INF/ui/tests`, but will be served
+from `http://localhost:8000/ui/tests`
+
+```js
+// Project configuration.
+grunt.initConfig({
+  qunit: {
+      options: {
+          httpBase: {
+              host: "http://localhost:8000",
+              doRewrite: function (file) {
+                  return file.replace("src/main/resources/META-INF/", "");
+              }
+          }
+      },	
+    all: ['src/main/resources/META-INF/ui/test/**/*.html']
+  }
+});
+```
+
 
 #### Using the grunt-contrib-connect plugin
 It's important to note that grunt does not automatically start a `localhost` web server. That being said, the [grunt-contrib-connect plugin][] `connect` task can be run before the `qunit` task to serve files via a simple [connect][] web server.

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -167,9 +167,22 @@ module.exports = function(grunt) {
     if (options.httpBase) {
       //If URLs are explicitly referenced, use them still
       urls = options.urls;
+      var httpBase = options.httpBase;
+      // check if httpBase is an object, then do
+      // object handling
+      var doUrlRewrite = false;
+      if(options.httpBase instanceof Object) {
+        // if there is no callback or no host throw error
+        if(!options.httpBase.host || !options.httpBase.doRewrite) {
+            grunt.log.error("If you define httpBase as an object you need to define httpBase.host and callback function httpBase.rewrite");
+        }
+        httpBase = options.httpBase.host;
+        doUrlRewrite = options.httpBase.doRewrite;
+      }
+
       // Then create URLs for the src files
       this.filesSrc.forEach(function(testFile) {
-        urls.push(options.httpBase + '/' + testFile);
+		urls.push(httpBase + '/' + ((doUrlRewrite instanceof Object) ? doUrlRewrite.call(this, testFile) : testFile));
       });
     } else {
       // Combine any specified URLs with src files.


### PR DESCRIPTION
Extended httpBase with an option to rewrite the file url.  Now it is possible to use `all` config together with a remote server and to map the url from filesystem to the corresponding format on the server.

``` js
// Project configuration.
grunt.initConfig({
  qunit: {
      options: {
          httpBase: {
              host: "http://localhost:8000",
              doRewrite: function (file) {
                  return file.replace("src/main/resources/META-INF/", "");
              }
          }
      },    
    all: ['src/main/resources/META-INF/ui/test/**/*.html']
  }
});
```
