### PR TITLE
Added "logFails" option to allow failed assertion logging to be disabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Nick Weingartner
 Schalk Neethling
 Shaker Islam
 Stephen Brandwood
+Sam Kirkpatrick

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Default: `false`
 Fail a test when the global namespace is polluted. See the [QUnit cookbook](http://qunitjs.com/cookbook/#discussion-id170) for more information.
 
 #### logFails
-Type: `boolean`
+Type: `boolean`  
 Default: `true`
 
 When false, failed assertions messages will not be output (particularly useful for automated build systems).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Default: `false`
 
 Fail a test when the global namespace is polluted. See the [QUnit cookbook](http://qunitjs.com/cookbook/#discussion-id170) for more information.
 
+#### logFails
+Type: `boolean`
+Default: `true`
+
+When false, failed assertions messages will not be output (particularly useful for automated build systems).
+
 ### Usage examples
 
 #### Wildcards

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -42,19 +42,21 @@ module.exports = function(grunt) {
   // Keep track of failed assertions for pretty-printing.
   var failedAssertions = [];
   var logFailedAssertions = function() {
-    var assertion;
-    // Print each assertion error.
-    while (assertion = failedAssertions.shift()) {
-      grunt.verbose.or.error(assertion.testName);
-      grunt.log.error('Message: ' + formatMessage(assertion.message));
-      if (assertion.actual !== assertion.expected) {
-        grunt.log.error('Actual: ' + formatMessage(assertion.actual));
-        grunt.log.error('Expected: ' + formatMessage(assertion.expected));
+    if (options && options.logFails) {
+      var assertion;
+      // Print each assertion error.
+      while (assertion = failedAssertions.shift()) {
+        grunt.verbose.or.error(assertion.testName);
+        grunt.log.error('Message: ' + formatMessage(assertion.message));
+        if (assertion.actual !== assertion.expected) {
+          grunt.log.error('Actual: ' + formatMessage(assertion.actual));
+          grunt.log.error('Expected: ' + formatMessage(assertion.expected));
+        }
+        if (assertion.source) {
+          grunt.log.error(assertion.source.replace(/ {4}(at)/g, '  $1'));
+        }
+        grunt.log.writeln();
       }
-      if (assertion.source) {
-        grunt.log.error(assertion.source.replace(/ {4}(at)/g, '  $1'));
-      }
-      grunt.log.writeln();
     }
   };
 
@@ -159,7 +161,9 @@ module.exports = function(grunt) {
       // Connect phantomjs console output to grunt output
       console: true,
       // Do not use an HTTP base by default
-      httpBase: false
+      httpBase: false,
+      // Log failed assertions by default
+      logFails: true
     });
 
     var urls;


### PR DESCRIPTION
We use this module within an automated build system and the logging out of assertion failures is causing us some issues. I've added an option to allow this to be disabled, should a developer or team wish to do so.