### PR TITLE
Effectively update PhantomJS to 2.1.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,8 +59,7 @@ module.exports = function(grunt) {
           urls: [
             'http://localhost:9000/test/qunit3.html?foo=bar'
           ]
-        },
-        src: 'test/qunit3.html'
+        }
       }
     }
 
@@ -85,8 +84,7 @@ module.exports = function(grunt) {
       'test/qunit1.html': 3,
       'test/qunit2.html': 3,
       'http://localhost:9000/test/qunit1.html': 2,
-      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=': 1,
-      'test/qunit3.html?noglobals=': 1
+      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=': 1
     };
     try {
       assert.deepEqual(actual, expected, 'Actual should match expected.');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "tasks/qunit.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test --stack"
   },
   "dependencies": {
     "grunt-lib-phantomjs": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "grunt-lib-phantomjs": "^0.6.0"
   },
   "devDependencies": {
-    "difflet": "^0.2.3",
+    "difflet": "^1.0.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-connect": "^0.9.0",
-    "grunt-contrib-internal": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.0",
-    "qunitjs": "^1.17.1"
+    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-internal": "^0.4.13",
+    "grunt-contrib-jshint": "^0.12.0",
+    "qunitjs": "^1.20.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-qunit",
   "description": "Run QUnit unit tests in a headless PhantomJS instance",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
@@ -16,7 +16,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "^0.6.0"
+    "grunt-lib-phantomjs": "^1.0.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",


### PR DESCRIPTION
Updates devDependencies in one commit, grunt-lib-phantomjs in another. The latter depends on https://github.com/gruntjs/grunt-lib-phantomjs/pull/96 getting merged and published, which is blocked by a PR further upstream.