### PR TITLE
Fix query string generation for noGlobals option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,7 +84,7 @@ module.exports = function(grunt) {
       'test/qunit1.html': 3,
       'test/qunit2.html': 3,
       'http://localhost:9000/test/qunit1.html': 2,
-      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=': 1
+      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=true': 1
     };
     try {
       assert.deepEqual(actual, expected, 'Actual should match expected.');

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -181,7 +181,7 @@ module.exports = function(grunt) {
       var parsed;
       urls = urls.map(function(testUrl) {
         parsed = url.parse(testUrl, true);
-        parsed.query.noglobals = "";
+        parsed.query.noglobals = "true";
         delete parsed.search;
         return url.format(parsed);
       });


### PR DESCRIPTION
Starting from `QUnit 1.22.0`, urls like `http://localhost:9000/test/qunit.html?noglobals=` are not valid anymore.

So the url should be either:

 * `http://localhost:9000/test/qunit.html?noglobals`
 * or `http://localhost:9000/test/qunit.html?noglobals=truthy-value`