### PR TITLE
Added 'summaryOnly' check around output of PhantomJS error traces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Schalk Neethling
 Shaker Islam
 Stephen Brandwood
 Mark Bailie (http://markbailie.co.uk)
+Sam Kirkpatrick

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -150,10 +150,6 @@ module.exports = function(grunt) {
 
   phantomjs.on('error.onError', function (msg, stackTrace) {
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
-
-    if (options && !options.summaryOnly) {
-      grunt.log.warn('PhantomJS error:\n', msg, '\n', stackTrace);
-    }
   });
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -150,7 +150,10 @@ module.exports = function(grunt) {
 
   phantomjs.on('error.onError', function (msg, stackTrace) {
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
-    grunt.log.warn('PhantomJS error:\n', msg, '\n', stackTrace);
+
+    if (options && !options.summaryOnly) {
+      grunt.log.warn('PhantomJS error:\n', msg, '\n', stackTrace);
+    }
   });
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {


### PR DESCRIPTION
Ref: PR #106 - originally rejected but has now been addressed by #117 - thank you!

We want to keep in sync with published package, but the logging of PhantomJS errors in our automated build is still causing us some problems. I've wrapped that `warn` in a check of the new 'summaryOnly' option which addresses our problem and hopefully shouldn't impact anyone not using it.

My only question might be whether re-using the 'summaryOnly' option is the right approach or whether a separate, independent option might be more appropriate. Thoughts?