### PR TITLE
Upgrade qunitjs to 2.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,8 +105,12 @@ module.exports = function(grunt) {
     currentUrl = url;
     if (!successes[currentUrl]) { successes[currentUrl] = 0; }
   });
-  grunt.event.on('qunit.done', function(failed, passed) {
-    if (failed === 0 && passed === 2) { successes[currentUrl]++; }
+  grunt.event.on('qunit.done', function(failed, passed, total) {
+    if (failed === 0 && passed === total) {
+      successes[currentUrl]++;
+    } else {
+      successes[currentUrl] -= 100;
+    }
   });
 
   grunt.registerTask('really-test', 'Test to see if qunit task actually worked.', function() {
@@ -117,7 +121,7 @@ module.exports = function(grunt) {
       'test/qunit1.html': 3,
       'test/qunit2.html': 3,
       'http://localhost:9000/test/qunit1.html': 2,
-      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=true': 1,
+      'http://localhost:9000/test/qunit3.html?foo=bar&noglobals=true': -100,
       'http://localhost:9000/test/qunit4.html' : 1,
       'http://localhost:9000/test/qunit5.html' : 1
     };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-internal": "^1.1.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-shell": "^1.3.0",
-    "qunitjs": "^1.20.0"
+    "qunitjs": "^2.3.0"
   },
   "keywords": [
     "gruntplugin"

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -18,8 +18,6 @@
 
   // Don't re-order tests.
   QUnit.config.reorder = false;
-  // Run tests serially, not in parallel.
-  QUnit.config.autorun = false;
 
   // Send messages to the parent PhantomJS process via alert! Good times!!
   function sendMessage() {

--- a/test/qunit_modules.js
+++ b/test/qunit_modules.js
@@ -1,14 +1,14 @@
-module('module1');
+QUnit.module('module1');
 
-test('basic test', function() {
-  expect(1);
-  ok(true, 'this had better work.');
+QUnit.test('basic test', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'this had better work.');
 });
 
 
-module('module2');
+QUnit.module('module2');
 
-test('a second basic test', function() {
-  expect(1);
-  ok(true, 'this had better work.');
+QUnit.test('a second basic test', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'this had better work.');
 });

--- a/test/qunit_noglobal_test.js
+++ b/test/qunit_noglobal_test.js
@@ -1,17 +1,15 @@
-
-var pushFailure = QUnit.pushFailure;
 var failures = [];
-
-test('global pollution', function(assert) {
-  window.pollute = true;
-  assert.ok(pollute, 'nasty pollution');
-  QUnit.pushFailure = function(message) {
-    failures.push(message);
-  };
+QUnit.log(function( details ) {
+  if (details.result === false)
+    failures.push(details.message);
 });
 
-test('actually check for global pollution', function() {
-  expect(1);
-  QUnit.pushFailure = pushFailure;
-  deepEqual(failures, ['Introduced global variable(s): pollute']);
+QUnit.todo('global pollution', function(assert) {
+  window.pollute = true;
+  assert.ok(pollute, 'nasty pollution');
+});
+
+QUnit.test('actually check for global pollution', function(assert) {
+  assert.expect(1);
+  assert.deepEqual(failures, ['Introduced global variable(s): pollute']);
 });

--- a/test/qunit_test.js
+++ b/test/qunit_test.js
@@ -1,12 +1,12 @@
 
-test('basic test', function() {
-  expect(1);
-  ok(true, 'this had better work.');
+QUnit.test('basic test', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'this had better work.');
 });
 
 
-test('can access the DOM', function() {
-  expect(1);
+QUnit.test('can access the DOM', function(assert) {
+  assert.expect(1);
   var fixture = document.getElementById('qunit-fixture');
-  equal(fixture.innerText, 'this had better work.', 'should be able to access the DOM.');
+  assert.equal(fixture.innerText, 'this had better work.', 'should be able to access the DOM.');
 });

--- a/test/qunit_test_error.js
+++ b/test/qunit_test_error.js
@@ -1,12 +1,12 @@
 
-test('basic test', function() {
-  expect(1);
-  ok(0, 'this had better work.');
+QUnit.test('basic test', function(assert) {
+  assert.expect(1);
+  assert.ok(0, 'this had better work.');
 });
 
 
-test('can access the DOM', function() {
-  expect(1);
+QUnit.test('can access the DOM', function(assert) {
+  assert.expect(1);
   var fixture = document.getElementById('qunit-fixture');
-  equal(fixture.innerText, 'this had better work.', 'should be able to access the DOM.');
+  assert.equal(fixture.innerText, 'this had better work.', 'should be able to access the DOM.');
 });


### PR DESCRIPTION
This is an in-progress implementation that fixes #122 .
- [x] Update bridge between phantomjs and qunit
  - Looks fine, except for [undocumented option](http://api.qunitjs.com/QUnit.config/) `QUnit.config.autorun = false`.  
    It's not mentioned in [upgrade guide](http://qunitjs.com/upgrade-guide-2.x/), so it _should_ continue to work.
- [x] Update tests as stated in upgrade guide
- [x] Change `devDependency` `qunitjs` from version `2.0.0-rc1` to `2.3.0`
- [ ] Update documentation to reflect the change
- [ ] Things I may have missed
