### PR TITLE
Error handling improvements

### DIFF
--- a/docs/qunit-options.md
+++ b/docs/qunit-options.md
@@ -55,19 +55,19 @@ Default: `false`
 Fail a test when the global namespace is polluted. See the [QUnit cookbook](http://qunitjs.com/cookbook/#discussion-id170) for more information.
 
 ## failOnScriptErrors
-Type: `boolean`
+Type: `boolean`  
 Default: `true`
 
 Fail a test if script error encountered.
 
 ## failOnMissingResources
-Type: `boolean`
+Type: `boolean`  
 Default: `false`
 
 Fail a test if PhantomJS failed to load a resource (scripts, etc.)
 
-## logResourcesEvents
-Type: `boolean`
+## printResourcesEvents
+Type: `boolean`  
 Default: `false`
 
 Print resource is missing or load timed out messages.

--- a/docs/qunit-options.md
+++ b/docs/qunit-options.md
@@ -40,7 +40,7 @@ When true, the whole task will not fail when there are individual test failures,
 Type: `boolean`  
 Default: `false`
 
-When true, this will suppress the default logging for individually failed tests. Customized logging can be performed by listening to and responding to `qunit.log` events.
+When true, this will suppress the default logging for individually failed tests. Customized logging can be performed by listening to and responding to `qunit.log` events. Also suppresses unhandled exceptions messages and JS erros and when `true` overrides `printResourcesEvents`.
 
 ## (-- PhantomJS arguments)
 Type: `String`  
@@ -70,7 +70,7 @@ Fail a test if PhantomJS failed to load a resource (scripts, etc.)
 Type: `boolean`  
 Default: `false`
 
-Print resource is missing or load timed out messages. Use `--verbose` for more details (error code and description).
+Print resource is missing or load timed out messages. Use `--verbose` for more details (error code and description). `summaryOnly = true` suppresses these messages.
 
 
 # Command line options

--- a/docs/qunit-options.md
+++ b/docs/qunit-options.md
@@ -70,7 +70,7 @@ Fail a test if PhantomJS failed to load a resource (scripts, etc.)
 Type: `boolean`  
 Default: `false`
 
-Print resource is missing or load timed out messages.
+Print resource is missing or load timed out messages. Use `--verbose` for more details (error code and description).
 
 
 # Command line options

--- a/docs/qunit-options.md
+++ b/docs/qunit-options.md
@@ -54,6 +54,25 @@ Default: `false`
 
 Fail a test when the global namespace is polluted. See the [QUnit cookbook](http://qunitjs.com/cookbook/#discussion-id170) for more information.
 
+## failOnScriptErrors
+Type: `boolean`
+Default: `true`
+
+Fail a test if script error encountered.
+
+## failOnMissingResources
+Type: `boolean`
+Default: `false`
+
+Fail a test if PhantomJS failed to load a resource (scripts, etc.)
+
+## logResourcesEvents
+Type: `boolean`
+Default: `false`
+
+Print resource is missing or load timed out messages.
+
+
 # Command line options
 
 ## Filtering by module name: `--modules`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "grunt test --stack"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "^1.0.0"
+    "grunt-lib-phantomjs": "^1.1.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -9,7 +9,7 @@
 /*global QUnit:true, alert:true*/
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    require(['qunit'], factory);
+    define('phantom-bridge', ['qunit'], factory);
   } else {
     factory(QUnit);
   }

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -178,10 +178,13 @@ module.exports = function(grunt) {
       status.total += 1;
     }
 
-    grunt.log.writeln();
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
-    grunt.log.error('Error on page: ' + msg);
-    grunt.verbose.error('Stack trace:' + stackTrace);
+
+    if (options && !options.summaryOnly) {
+      grunt.log.writeln();
+      grunt.log.error('Error on page: ' + msg);
+      grunt.verbose.error('Stack trace:' + stackTrace);
+    }
   });
 
   phantomjs.on('error.onResourceError', function (resourceError) {
@@ -191,7 +194,7 @@ module.exports = function(grunt) {
       status.total += 1;
     }
 
-    if (options && options.printResourcesEvents) {
+    if (options && options.printResourcesEvents && !options.summaryOnly) {
       grunt.log.writeln();
       grunt.event.emit('qunit.error.onError', resourceError);
       grunt.log.error('Unable to load resource: ' + resourceError.url);
@@ -206,7 +209,7 @@ module.exports = function(grunt) {
       status.total += 1;
     }
 
-    if (options && options.printResourcesEvents) {
+    if (options && options.printResourcesEvents && !options.summaryOnly) {
       grunt.log.writeln();
       grunt.event.emit('qunit.error.onError', resourceError);
       grunt.log.error('Timeout while loading resource: ' + resourceError.url);

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -172,7 +172,17 @@ module.exports = function(grunt) {
   });
 
   phantomjs.on('error.onError', function (msg, stackTrace) {
+    grunt.log.writeln();
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
+    grunt.log.error('Error on page: ' + msg);
+    grunt.verbose.error('Stack trace:' + stackTrace);
+  });
+
+  phantomjs.on('error.resourceError', function (resourceError) {
+    grunt.log.writeln();
+    grunt.event.emit('qunit.error.onError', resourceError);
+    grunt.log.error('Unable to load resource: ' + resourceError.url);
+    grunt.verbose.error('Error code: ' + resourceError.errorCode + "; Description: " + resourceError.errorString);
   });
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -191,7 +191,7 @@ module.exports = function(grunt) {
       status.total += 1;
     }
 
-    if (options && options.logResourcesEvents) {
+    if (options && options.printResourcesEvents) {
       grunt.log.writeln();
       grunt.event.emit('qunit.error.onError', resourceError);
       grunt.log.error('Unable to load resource: ' + resourceError.url);
@@ -206,7 +206,7 @@ module.exports = function(grunt) {
       status.total += 1;
     }
 
-    if (options && options.logResourcesEvents) {
+    if (options && options.printResourcesEvents) {
       grunt.log.writeln();
       grunt.event.emit('qunit.error.onError', resourceError);
       grunt.log.error('Timeout while loading resource: ' + resourceError.url);
@@ -234,7 +234,7 @@ module.exports = function(grunt) {
       // Stop if failed to load resource (scripts, etc.)
       failOnMissingResources: false,
       // Print resource is missing or load timed out messages
-      logResourcesEvents: false
+      printResourcesEvents: false
     });
 
     var urls;


### PR DESCRIPTION
1. A number of config options added that control abortion of testing if script or resource loading error encountered;
2. An option to print script errors and resource is missing errors is added and it is enabled by default;
3. phantomjs/bridge.js initializes incorrectly when requirejs is present. Factory func called as soon as script injected which happens before requirejs configured which leads invalid attempts to find qunit dependency at invalid locations. Basically there is no automatic way to initialize bridge with requirejs, users have to explicitly require dependency to `phantom-bridge` in their app's bootstrap scripts like this:

``` require(
    [
      'jquery',
      'angular',
      'app/app',
      'qunit',
      'phantom-bridge'
    ],
    function()
    {
        // ....
    });
```

All that helps adopt headless qunit testing faster without frustrating PhantomJS timeout errors that implicitly caused by requirejs misuse and silent script errors.
