### PR TITLE
Implement support for todo tests and revamp reporting logic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
       options: {
         callback: function(err, stdout, stderr, cb) {
           if (/test\/qunit[45]\.html/.test(stdout) &&
-              /[12] assertions passed/.test(stdout)) {
+              /passed: [12]/.test(stdout)) {
             cb();
           } else {
             cb(false);

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -54,7 +54,7 @@
   });
 
   QUnit.testDone(function(obj) {
-    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration, obj.todo);
+    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.runtime, obj.skipped, obj.todo);
   });
 
   QUnit.moduleStart(function(obj) {

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -46,7 +46,7 @@
       expected = dump.parse(obj.expected);
     }
     // Send it.
-    sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);
+    sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source, obj.todo);
   });
 
   QUnit.testStart(function(obj) {
@@ -54,7 +54,7 @@
   });
 
   QUnit.testDone(function(obj) {
-    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration);
+    sendMessage('qunit.testDone', obj.name, obj.failed, obj.passed, obj.total, obj.duration, obj.todo);
   });
 
   QUnit.moduleStart(function(obj) {


### PR DESCRIPTION
In order to support `QUnit.todo()`, the reporting logic for this package needed to be revamped.

Previously, pass/fail was determined by the presence of individual failing assertions. With `todo`, it is possible to have failing assertions without having a failing test suite. Thus, the logic for deciding whether or not a suite has failed needs to deal with the status of complete tests rather than individual assertions. That is what the bulk of this PR does.

It also changes the summary text to be of a standard format like so:

```
>> 210 tests completed with 0 failed, 6 skipped, and 1 todo. 
>> 682 assertions (in 2638ms), passed: 681, failed: 1
```

Previously, you could get 1 of 3 different variation depending on the combination of passed/failed assertions your suite had.

cc @leobalter 