### PR TITLE
Restore page timeout handling and `fail.timeout` event

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,9 @@ module.exports = function(grunt) {
           if (/test\/qunit[45]\.html/.test(stdout) &&
               /passed: [12]/.test(stdout)) {
             cb();
+          } else if (/test\/qunit_page_timeout\.html/.test(stdout) &&
+              /Chrome timed out/.test(stdout)) {
+            cb();
           } else {
             cb(false);
           }
@@ -108,10 +111,24 @@ module.exports = function(grunt) {
       },
       seed: {
         command: 'grunt qunit:seed --seed="7x9"'
+      },
+      pageTimeout: {
+        command: 'grunt qunit:failPageTimeout --with-failpagetimeout'
       }
     }
 
   });
+
+  // Only register this failing task for the shell task that expects the failure
+  if (grunt.option('with-failpagetimeout')) {
+    grunt.config.set('qunit.failPageTimeout', {
+      options: {
+        urls: [
+          'http://localhost:9000/test/qunit_page_timeout.html'
+        ]
+      }
+    });
+  }
 
   // Build a mapping of url success counters.
   var successes = {};

--- a/chrome/bridge.js
+++ b/chrome/bridge.js
@@ -16,12 +16,26 @@
 }(function(QUnit) {
   'use strict';
 
+  var lastMessage = performance.now();
+
   // Don't re-order tests.
   QUnit.config.reorder = false;
 
   // Send messages to the Node process
   function sendMessage() {
     self.__grunt_contrib_qunit__.apply(self, [].slice.call(arguments));
+    lastMessage = performance.now();
+  }
+
+  if (self.__grunt_contrib_qunit_timeout__) {
+    setTimeout(function checkTimeout() {
+      if ((performance.now() - lastMessage) > self.__grunt_contrib_qunit_timeout__) {
+        sendMessage('fail.timeout');
+      } else {
+        // Keep checking
+        setTimeout(checkTimeout, 1000);
+      }
+    }, 1000);
   }
 
   // These methods connect QUnit to Headless Chrome.

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -295,7 +295,9 @@ module.exports = function(grunt) {
 
     // Read the content of the specified bridge files
     var bridgeFiles = Array.isArray(options.inject) ? options.inject : [options.inject];
-    var bridgContents = [];
+    var bridgContents = [
+      "__grunt_contrib_qunit_timeout__ = " + JSON.stringify( options.timeout ) + ";"
+    ];
 
     for (var i = 0; i < bridgeFiles.length; i++) {
       try {

--- a/test/qunit_page_timeout.html
+++ b/test/qunit_page_timeout.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Suite</title>
+  <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" media="screen">
+  <script src="../node_modules/qunit/qunit/qunit.js"></script>
+  <script src="qunit_page_timeout.js"></script>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/qunit_page_timeout.js
+++ b/test/qunit_page_timeout.js
@@ -1,0 +1,7 @@
+QUnit.module('grunt-contrib-qunit timeout');
+
+QUnit.test('last forever', function(assert) {
+  var done = assert.async();
+
+  assert.ok( true );
+});


### PR DESCRIPTION
Follows b35e7ce1b4 and https://github.com/gruntjs/grunt-contrib-qunit/pull/147, which converted the plugin from PhantomJS to Headless Chromium.

While `options.timeout` is still used for the navigation, it was no longer used to stop tasks that have crashed, broken or are timing out for other reasons at runtime.

The approach of using an interval in the bridge is based on [the original grunt-lib-phantomjs code](https://github.com/gruntjs/grunt-lib-phantomjs/blob/v1.1.0/phantomjs/main.js#L43-L51). I modified it to use a more graceful setTimeout recursion instead, and changed the "end" logic from a direct `exit()` call (which is not possible in chrome bridge), to simply not recursing further.

The exit handling is already in place in tasks/qunit.js, where an `on("fail.*")` listener exists (though seemingly not utilised until now), which includes an indirect call to `browser.close()`.

Fixes https://github.com/gruntjs/grunt-contrib-qunit/issues/178.