### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "eventemitter2": "^6.4.2",
     "p-each-series": "^2.1.0",
-    "puppeteer": "^5.0.0"
+    "puppeteer": "^10.1.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",


### PR DESCRIPTION
There is a problem with old version of puppeteer on macbook with M1 silicon computer. Please update puppeteer dependency to 10.1.0.
It will work fine that way.