### PR TITLE
Migrate reporting logic to `QUnit.on()` events API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
         callback: function(err, stdout, stderr, cb) {
           // qunit:modules, qunit:seed
           if (/test\/(qunit_modules|qunit_seed)\.html/.test(stdout) &&
-              /passed: [12]/.test(stdout)) {
+              /[12] tests completed.*, with 0 failed/.test(stdout)) {
             cb(err === null);
 
           // qunit:failAssert
@@ -175,8 +175,8 @@ module.exports = function(grunt) {
       successes[currentUrl] = 0;
     }
   });
-  grunt.event.on('qunit.done', function(failed, passed, total) {
-    if (failed === 0 && passed === total) {
+  grunt.event.on('qunit.on.runEnd', function(runEnd) {
+    if (runEnd.status === 'passed') {
       successes[currentUrl]++;
     } else {
       successes[currentUrl] -= 100;
@@ -191,7 +191,7 @@ module.exports = function(grunt) {
       'test/qunit_basic1.html': 3,
       'test/qunit_basic2.html': 3,
       'http://localhost:9000/test/qunit_basic1.html': 2,
-      'http://localhost:9000/test/qunit_noglobals.html?foo=bar&noglobals=true': -100,
+      'http://localhost:9000/test/qunit_noglobals.html?foo=bar&noglobals=true': 1,
       'http://localhost:9000/test/qunit_modules.html': 1,
       'http://localhost:9000/test/qunit_seed.html': 1
     };

--- a/chrome/bridge.js
+++ b/chrome/bridge.js
@@ -38,7 +38,34 @@
     }, 1000);
   }
 
-  // These methods connect QUnit to Headless Chrome.
+  // QUnit reporter events
+  // https://api.qunitjs.com/callbacks/QUnit.on/
+
+  QUnit.on('testStart', function(obj) {
+    sendMessage('qunit.on.testStart', obj);
+  });
+
+  QUnit.on('testEnd', function(obj) {
+    sendMessage('qunit.on.testEnd', obj);
+  });
+
+  QUnit.on('runEnd', function(obj) {
+    // Re-create object to strip out large 'tests' field (deprecated).
+    sendMessage('qunit.on.runEnd', {
+      testCounts: obj.testCounts,
+      runtime: obj.runtime,
+      status: obj.status
+    });
+  });
+
+  // QUnit plugin callbacks (for back-compat)
+  // https://api.qunitjs.com/callbacks/
+  //
+  // TODO: Remove the below in a future major version of grunt-contrib-qunit,
+  // after updating docs for grunt.event.on() and announcing their deprecation,
+  // to give developers time to migrate any event consumers to their
+  // newer equivalents.
+
   QUnit.log(function(obj) {
     // What is this I don’t even
     if (obj.message === '[object Object], undefined:undefined') {


### PR DESCRIPTION
### Why

* Higher level API, exists for this purpose, thus resulting in simpler code that has to know less about QUnit internals.

* Solves a number of problems, including two issues that would make CI on this repo fail if we updated its devDependencies to the latest qunit as-is.

### Change

Remove all manual tracking of `QUnit.log()` and custom interpreting of results. Simply listen to `QUnit.on()` for "testStart", "testEnd" and "runEnd", and rhen report their counts, details, and boolean status as-is.

The main observable change is that the printed success line is now one line instead of two:

Before:
> 2 tests completed with 0 failed, 0 skipped, and 0 todo.
> 2 assertions (in 9ms), passed: 2, failed: 0

After:
> 2 tests completed in 9ms, with 0 failed, 0 skipped, and 0 todo.

This is the same text as displayed in the browser.

### Details

The task previously tracked individually logged assertions, decided if it's a failure, and filtered out expected failures in a "todo" test from actually unexpected failures.

This resulted in the odd situation where `QUnit.done()` is given a count but the task did not use it to decide whether the grunt task is a success, because this would not account for "todo" tests, and thus in https://github.com/gruntjs/grunt-contrib-qunit/pull/137 the logic grew even further. In QUnit 2.17 the reporting of global failures from window.onerror
changed and the logic here was now stale and no longer reporting it correctly.

Also, the qunit_noglobals.html case was wrongly counted as a failing test because the logic checked `failed === 0 && passed === total` based on raw assertion count, which again, does not account for "todo" tests. The `qunit_noglobals.html` is actually a passing test when opened in the browser, but the local Gruntfile logic treated it as a failure.

Both of these two problems are naturally fixed by this patch, and so the next commit that updates QUnit in this repo's CI to the latest will continue to pass instead of having these two failures.