### PR TITLE
Inject bridge.js into top frame only

### DIFF
--- a/chrome/bridge.js
+++ b/chrome/bridge.js
@@ -9,6 +9,7 @@
 /* global QUnit:true */
 (function (factory) {
   if (window.self !== window.top) {
+    // Ignore iframes. https://github.com/gruntjs/grunt-contrib-qunit/issues/202
     return;
   }
   if (typeof define === 'function' && define.amd) {

--- a/chrome/bridge.js
+++ b/chrome/bridge.js
@@ -8,6 +8,9 @@
 
 /* global QUnit:true */
 (function (factory) {
+  if (window.self !== window.top) {
+    return;
+  }
   if (typeof define === 'function' && define.amd) {
     require(['qunit'], factory);
   } else {


### PR DESCRIPTION
Fix for #202 

This PR adds a conditional check to the Chrome `bridge.js` file such that it is only injected into the top most frame.

This has been tested locally on the ClassicPress repository install and resolved the reported Error: ReferenceError: QUnit is not defined" issue.