### PR TITLE
docs: Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+## Reporting a vulnerability
+
+If you discover a security vulnerability within grunt, please submit a report via the Github's Private Vulnerability Reporting feature.
+
+All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
I've enabled the "Private vulnerability reporting" at https://github.com/gruntjs/grunt-contrib-qunit/security.

I considered pointing this to `security@jquery.com` to match what we do in https://github.com/qunitjs/qunit/ and https://github.com/qunitjs/node-qunit/, but I figured for improved visibility and ease of collaborating with maintainers of other grunt plugins, perhaps better to use the same mechanism and policy as gruntjs/grunt.

/cc @vladikoff FYI :)

Ref https://github.com/gruntjs/grunt/issues/1770.
